### PR TITLE
Example of using membuffers for serialization/deserialization

### DIFF
--- a/examples/membuffers/phonebook/contract.go
+++ b/examples/membuffers/phonebook/contract.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/hex"
+	"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1"
+	"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/address"
+	"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/state"
+	"strconv"
+	"strings"
+)
+
+var PUBLIC = sdk.Export(register, get, list)
+var SYSTEM = sdk.Export(_init)
+
+func _init() {
+
+}
+
+func toAddress(input string) string {
+	if len(input) > 40 {
+		input = input[2:42]
+	}
+	return strings.ToLower(input)
+}
+
+// Takes PhonebookEntry as bytes
+func register(payload []byte) {
+	entry := PhonebookEntryReader(payload)
+	entry.MutateOrbsAddress(address.GetSignerAddress())
+
+	state.WriteBytes(_entryKey(address.GetSignerAddress()), entry.Raw())
+	state.WriteBytes(_listKey(_counter()), address.GetSignerAddress())
+	_inc()
+}
+
+// Returns PhonebookEntry as bytes
+func get(address []byte) []byte {
+	return state.ReadBytes(_entryKey(address))
+}
+
+// Returns PhonebookEntryList as bytes
+func list() []byte {
+	var entries []*PhonebookEntryBuilder
+
+	counter := _counter()
+	for i := uint64(0); i < counter ; i ++ {
+		addr := state.ReadBytes(_listKey(i))
+		reader := PhonebookEntryReader(state.ReadBytes(_entryKey(addr)));
+
+		builder := &PhonebookEntryBuilder{
+			FirstName: reader.FirstName(),
+			LastName: reader.LastName(),
+			Phone: reader.Phone(),
+			OrbsAddress: reader.OrbsAddress(),
+		}
+		entries = append(entries, builder)
+	}
+
+
+	list := &PhonebookEntryListBuilder{
+		List: entries,
+	}
+
+	return list.Build().Raw()
+}
+
+func _entryKey(address []byte) []byte {
+	return []byte(toAddress(hex.EncodeToString(address)))
+}
+
+func _listKey(i uint64) []byte {
+	return []byte("entry_" + strconv.FormatUint(i, 10))
+}
+
+var COUNTER_KEY = []byte("entries_total")
+
+func _inc() uint64 {
+	v := _counter() + 1
+	state.WriteUint64(COUNTER_KEY, v)
+	return v
+}
+
+func _counter() uint64 {
+	return state.ReadUint64(COUNTER_KEY)
+}

--- a/examples/membuffers/phonebook/datastructures.mb.go
+++ b/examples/membuffers/phonebook/datastructures.mb.go
@@ -1,0 +1,381 @@
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.21)
+package main
+
+import (
+	"github.com/orbs-network/membuffers/go"
+	"bytes"
+	"fmt"
+)
+
+/////////////////////////////////////////////////////////////////////////////
+// message PhonebookEntryList
+
+// reader
+
+type PhonebookEntryList struct {
+	// List []PhonebookEntry
+
+	// internal
+	// implements membuffers.Message
+	_message membuffers.InternalMessage
+}
+
+func (x *PhonebookEntryList) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{List:%s,}", x.StringList())
+}
+
+var _PhonebookEntryList_Scheme = []membuffers.FieldType{membuffers.TypeMessageArray,}
+var _PhonebookEntryList_Unions = [][]membuffers.FieldType{}
+
+func PhonebookEntryListReader(buf []byte) *PhonebookEntryList {
+	x := &PhonebookEntryList{}
+	x._message.Init(buf, membuffers.Offset(len(buf)), _PhonebookEntryList_Scheme, _PhonebookEntryList_Unions)
+	return x
+}
+
+func (x *PhonebookEntryList) IsValid() bool {
+	return x._message.IsValid()
+}
+
+func (x *PhonebookEntryList) Raw() []byte {
+	return x._message.RawBuffer()
+}
+
+func (x *PhonebookEntryList) Equal(y *PhonebookEntryList) bool {
+  if x == nil && y == nil {
+    return true
+  }
+  if x == nil || y == nil {
+    return false
+  }
+  return bytes.Equal(x.Raw(), y.Raw())
+}
+
+func (x *PhonebookEntryList) ListIterator() *PhonebookEntryListListIterator {
+	return &PhonebookEntryListListIterator{iterator: x._message.GetMessageArrayIterator(0)}
+}
+
+type PhonebookEntryListListIterator struct {
+	iterator *membuffers.Iterator
+}
+
+func (i *PhonebookEntryListListIterator) HasNext() bool {
+	return i.iterator.HasNext()
+}
+
+func (i *PhonebookEntryListListIterator) NextList() *PhonebookEntry {
+	b, s := i.iterator.NextMessage()
+	return PhonebookEntryReader(b[:s])
+}
+
+func (x *PhonebookEntryList) RawListArray() []byte {
+	return x._message.RawBufferForField(0, 0)
+}
+
+func (x *PhonebookEntryList) RawListArrayWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(0, 0)
+}
+
+func (x *PhonebookEntryList) StringList() (res string) {
+	res = "["
+	for i := x.ListIterator(); i.HasNext(); {
+		res += i.NextList().String() + ","
+	}
+	res += "]"
+	return
+}
+
+// builder
+
+type PhonebookEntryListBuilder struct {
+	List []*PhonebookEntryBuilder
+
+	// internal
+	// implements membuffers.Builder
+	_builder membuffers.InternalBuilder
+	_overrideWithRawBuffer []byte
+}
+
+func (w *PhonebookEntryListBuilder) arrayOfList() []membuffers.MessageWriter {
+	res := make([]membuffers.MessageWriter, len(w.List))
+	for i, v := range w.List {
+		res[i] = v
+	}
+	return res
+}
+
+func (w *PhonebookEntryListBuilder) Write(buf []byte) (err error) {
+	if w == nil {
+		return
+	}
+	w._builder.NotifyBuildStart()
+	defer w._builder.NotifyBuildEnd()
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	if w._overrideWithRawBuffer != nil {
+		return w._builder.WriteOverrideWithRawBuffer(buf, w._overrideWithRawBuffer)
+	}
+	w._builder.Reset()
+	err = w._builder.WriteMessageArray(buf, w.arrayOfList())
+	if err != nil {
+		return
+	}
+	return nil
+}
+
+func (w *PhonebookEntryListBuilder) HexDump(prefix string, offsetFromStart membuffers.Offset) (err error) {
+	if w == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	w._builder.Reset()
+	err = w._builder.HexDumpMessageArray(prefix, offsetFromStart, "PhonebookEntryList.List", w.arrayOfList())
+	if err != nil {
+		return
+	}
+	return nil
+}
+
+func (w *PhonebookEntryListBuilder) GetSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryListBuilder) CalcRequiredSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	w.Write(nil)
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryListBuilder) Build() *PhonebookEntryList {
+	buf := make([]byte, w.CalcRequiredSize())
+	if w.Write(buf) != nil {
+		return nil
+	}
+	return PhonebookEntryListReader(buf)
+}
+
+func PhonebookEntryListBuilderFromRaw(raw []byte) *PhonebookEntryListBuilder {
+	return &PhonebookEntryListBuilder{_overrideWithRawBuffer: raw}
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message PhonebookEntry
+
+// reader
+
+type PhonebookEntry struct {
+	// FirstName string
+	// LastName string
+	// Phone uint64
+	// OrbsAddress []byte
+
+	// internal
+	// implements membuffers.Message
+	_message membuffers.InternalMessage
+}
+
+func (x *PhonebookEntry) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{FirstName:%s,LastName:%s,Phone:%s,OrbsAddress:%s,}", x.StringFirstName(), x.StringLastName(), x.StringPhone(), x.StringOrbsAddress())
+}
+
+var _PhonebookEntry_Scheme = []membuffers.FieldType{membuffers.TypeString,membuffers.TypeString,membuffers.TypeUint64,membuffers.TypeBytes,}
+var _PhonebookEntry_Unions = [][]membuffers.FieldType{}
+
+func PhonebookEntryReader(buf []byte) *PhonebookEntry {
+	x := &PhonebookEntry{}
+	x._message.Init(buf, membuffers.Offset(len(buf)), _PhonebookEntry_Scheme, _PhonebookEntry_Unions)
+	return x
+}
+
+func (x *PhonebookEntry) IsValid() bool {
+	return x._message.IsValid()
+}
+
+func (x *PhonebookEntry) Raw() []byte {
+	return x._message.RawBuffer()
+}
+
+func (x *PhonebookEntry) Equal(y *PhonebookEntry) bool {
+  if x == nil && y == nil {
+    return true
+  }
+  if x == nil || y == nil {
+    return false
+  }
+  return bytes.Equal(x.Raw(), y.Raw())
+}
+
+func (x *PhonebookEntry) FirstName() string {
+	return x._message.GetString(0)
+}
+
+func (x *PhonebookEntry) RawFirstName() []byte {
+	return x._message.RawBufferForField(0, 0)
+}
+
+func (x *PhonebookEntry) RawFirstNameWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(0, 0)
+}
+
+func (x *PhonebookEntry) MutateFirstName(v string) error {
+	return x._message.SetString(0, v)
+}
+
+func (x *PhonebookEntry) StringFirstName() string {
+	return fmt.Sprintf(x.FirstName())
+}
+
+func (x *PhonebookEntry) LastName() string {
+	return x._message.GetString(1)
+}
+
+func (x *PhonebookEntry) RawLastName() []byte {
+	return x._message.RawBufferForField(1, 0)
+}
+
+func (x *PhonebookEntry) RawLastNameWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(1, 0)
+}
+
+func (x *PhonebookEntry) MutateLastName(v string) error {
+	return x._message.SetString(1, v)
+}
+
+func (x *PhonebookEntry) StringLastName() string {
+	return fmt.Sprintf(x.LastName())
+}
+
+func (x *PhonebookEntry) Phone() uint64 {
+	return x._message.GetUint64(2)
+}
+
+func (x *PhonebookEntry) RawPhone() []byte {
+	return x._message.RawBufferForField(2, 0)
+}
+
+func (x *PhonebookEntry) MutatePhone(v uint64) error {
+	return x._message.SetUint64(2, v)
+}
+
+func (x *PhonebookEntry) StringPhone() string {
+	return fmt.Sprintf("%x", x.Phone())
+}
+
+func (x *PhonebookEntry) OrbsAddress() []byte {
+	return x._message.GetBytes(3)
+}
+
+func (x *PhonebookEntry) RawOrbsAddress() []byte {
+	return x._message.RawBufferForField(3, 0)
+}
+
+func (x *PhonebookEntry) RawOrbsAddressWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(3, 0)
+}
+
+func (x *PhonebookEntry) MutateOrbsAddress(v []byte) error {
+	return x._message.SetBytes(3, v)
+}
+
+func (x *PhonebookEntry) StringOrbsAddress() string {
+	return fmt.Sprintf("%x", x.OrbsAddress())
+}
+
+// builder
+
+type PhonebookEntryBuilder struct {
+	FirstName string
+	LastName string
+	Phone uint64
+	OrbsAddress []byte
+
+	// internal
+	// implements membuffers.Builder
+	_builder membuffers.InternalBuilder
+	_overrideWithRawBuffer []byte
+}
+
+func (w *PhonebookEntryBuilder) Write(buf []byte) (err error) {
+	if w == nil {
+		return
+	}
+	w._builder.NotifyBuildStart()
+	defer w._builder.NotifyBuildEnd()
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	if w._overrideWithRawBuffer != nil {
+		return w._builder.WriteOverrideWithRawBuffer(buf, w._overrideWithRawBuffer)
+	}
+	w._builder.Reset()
+	w._builder.WriteString(buf, w.FirstName)
+	w._builder.WriteString(buf, w.LastName)
+	w._builder.WriteUint64(buf, w.Phone)
+	w._builder.WriteBytes(buf, w.OrbsAddress)
+	return nil
+}
+
+func (w *PhonebookEntryBuilder) HexDump(prefix string, offsetFromStart membuffers.Offset) (err error) {
+	if w == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	w._builder.Reset()
+	w._builder.HexDumpString(prefix, offsetFromStart, "PhonebookEntry.FirstName", w.FirstName)
+	w._builder.HexDumpString(prefix, offsetFromStart, "PhonebookEntry.LastName", w.LastName)
+	w._builder.HexDumpUint64(prefix, offsetFromStart, "PhonebookEntry.Phone", w.Phone)
+	w._builder.HexDumpBytes(prefix, offsetFromStart, "PhonebookEntry.OrbsAddress", w.OrbsAddress)
+	return nil
+}
+
+func (w *PhonebookEntryBuilder) GetSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryBuilder) CalcRequiredSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	w.Write(nil)
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryBuilder) Build() *PhonebookEntry {
+	buf := make([]byte, w.CalcRequiredSize())
+	if w.Write(buf) != nil {
+		return nil
+	}
+	return PhonebookEntryReader(buf)
+}
+
+func PhonebookEntryBuilderFromRaw(raw []byte) *PhonebookEntryBuilder {
+	return &PhonebookEntryBuilder{_overrideWithRawBuffer: raw}
+}
+

--- a/examples/membuffers/phonebook/datastructures.proto
+++ b/examples/membuffers/phonebook/datastructures.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package main;
+
+message PhonebookEntryList {
+    repeated PhonebookEntry list = 1;
+}
+
+message PhonebookEntry {
+   string first_name = 1;
+   string last_name = 2;
+
+   uint64 phone = 3;
+   bytes orbs_address = 4;
+}

--- a/examples/membuffers/test/datastructures.mb.go
+++ b/examples/membuffers/test/datastructures.mb.go
@@ -1,0 +1,381 @@
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.21)
+package test
+
+import (
+	"github.com/orbs-network/membuffers/go"
+	"bytes"
+	"fmt"
+)
+
+/////////////////////////////////////////////////////////////////////////////
+// message PhonebookEntryList
+
+// reader
+
+type PhonebookEntryList struct {
+	// List []PhonebookEntry
+
+	// internal
+	// implements membuffers.Message
+	_message membuffers.InternalMessage
+}
+
+func (x *PhonebookEntryList) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{List:%s,}", x.StringList())
+}
+
+var _PhonebookEntryList_Scheme = []membuffers.FieldType{membuffers.TypeMessageArray,}
+var _PhonebookEntryList_Unions = [][]membuffers.FieldType{}
+
+func PhonebookEntryListReader(buf []byte) *PhonebookEntryList {
+	x := &PhonebookEntryList{}
+	x._message.Init(buf, membuffers.Offset(len(buf)), _PhonebookEntryList_Scheme, _PhonebookEntryList_Unions)
+	return x
+}
+
+func (x *PhonebookEntryList) IsValid() bool {
+	return x._message.IsValid()
+}
+
+func (x *PhonebookEntryList) Raw() []byte {
+	return x._message.RawBuffer()
+}
+
+func (x *PhonebookEntryList) Equal(y *PhonebookEntryList) bool {
+  if x == nil && y == nil {
+    return true
+  }
+  if x == nil || y == nil {
+    return false
+  }
+  return bytes.Equal(x.Raw(), y.Raw())
+}
+
+func (x *PhonebookEntryList) ListIterator() *PhonebookEntryListListIterator {
+	return &PhonebookEntryListListIterator{iterator: x._message.GetMessageArrayIterator(0)}
+}
+
+type PhonebookEntryListListIterator struct {
+	iterator *membuffers.Iterator
+}
+
+func (i *PhonebookEntryListListIterator) HasNext() bool {
+	return i.iterator.HasNext()
+}
+
+func (i *PhonebookEntryListListIterator) NextList() *PhonebookEntry {
+	b, s := i.iterator.NextMessage()
+	return PhonebookEntryReader(b[:s])
+}
+
+func (x *PhonebookEntryList) RawListArray() []byte {
+	return x._message.RawBufferForField(0, 0)
+}
+
+func (x *PhonebookEntryList) RawListArrayWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(0, 0)
+}
+
+func (x *PhonebookEntryList) StringList() (res string) {
+	res = "["
+	for i := x.ListIterator(); i.HasNext(); {
+		res += i.NextList().String() + ","
+	}
+	res += "]"
+	return
+}
+
+// builder
+
+type PhonebookEntryListBuilder struct {
+	List []*PhonebookEntryBuilder
+
+	// internal
+	// implements membuffers.Builder
+	_builder membuffers.InternalBuilder
+	_overrideWithRawBuffer []byte
+}
+
+func (w *PhonebookEntryListBuilder) arrayOfList() []membuffers.MessageWriter {
+	res := make([]membuffers.MessageWriter, len(w.List))
+	for i, v := range w.List {
+		res[i] = v
+	}
+	return res
+}
+
+func (w *PhonebookEntryListBuilder) Write(buf []byte) (err error) {
+	if w == nil {
+		return
+	}
+	w._builder.NotifyBuildStart()
+	defer w._builder.NotifyBuildEnd()
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	if w._overrideWithRawBuffer != nil {
+		return w._builder.WriteOverrideWithRawBuffer(buf, w._overrideWithRawBuffer)
+	}
+	w._builder.Reset()
+	err = w._builder.WriteMessageArray(buf, w.arrayOfList())
+	if err != nil {
+		return
+	}
+	return nil
+}
+
+func (w *PhonebookEntryListBuilder) HexDump(prefix string, offsetFromStart membuffers.Offset) (err error) {
+	if w == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	w._builder.Reset()
+	err = w._builder.HexDumpMessageArray(prefix, offsetFromStart, "PhonebookEntryList.List", w.arrayOfList())
+	if err != nil {
+		return
+	}
+	return nil
+}
+
+func (w *PhonebookEntryListBuilder) GetSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryListBuilder) CalcRequiredSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	w.Write(nil)
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryListBuilder) Build() *PhonebookEntryList {
+	buf := make([]byte, w.CalcRequiredSize())
+	if w.Write(buf) != nil {
+		return nil
+	}
+	return PhonebookEntryListReader(buf)
+}
+
+func PhonebookEntryListBuilderFromRaw(raw []byte) *PhonebookEntryListBuilder {
+	return &PhonebookEntryListBuilder{_overrideWithRawBuffer: raw}
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message PhonebookEntry
+
+// reader
+
+type PhonebookEntry struct {
+	// FirstName string
+	// LastName string
+	// Phone uint64
+	// OrbsAddress []byte
+
+	// internal
+	// implements membuffers.Message
+	_message membuffers.InternalMessage
+}
+
+func (x *PhonebookEntry) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{FirstName:%s,LastName:%s,Phone:%s,OrbsAddress:%s,}", x.StringFirstName(), x.StringLastName(), x.StringPhone(), x.StringOrbsAddress())
+}
+
+var _PhonebookEntry_Scheme = []membuffers.FieldType{membuffers.TypeString,membuffers.TypeString,membuffers.TypeUint64,membuffers.TypeBytes,}
+var _PhonebookEntry_Unions = [][]membuffers.FieldType{}
+
+func PhonebookEntryReader(buf []byte) *PhonebookEntry {
+	x := &PhonebookEntry{}
+	x._message.Init(buf, membuffers.Offset(len(buf)), _PhonebookEntry_Scheme, _PhonebookEntry_Unions)
+	return x
+}
+
+func (x *PhonebookEntry) IsValid() bool {
+	return x._message.IsValid()
+}
+
+func (x *PhonebookEntry) Raw() []byte {
+	return x._message.RawBuffer()
+}
+
+func (x *PhonebookEntry) Equal(y *PhonebookEntry) bool {
+  if x == nil && y == nil {
+    return true
+  }
+  if x == nil || y == nil {
+    return false
+  }
+  return bytes.Equal(x.Raw(), y.Raw())
+}
+
+func (x *PhonebookEntry) FirstName() string {
+	return x._message.GetString(0)
+}
+
+func (x *PhonebookEntry) RawFirstName() []byte {
+	return x._message.RawBufferForField(0, 0)
+}
+
+func (x *PhonebookEntry) RawFirstNameWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(0, 0)
+}
+
+func (x *PhonebookEntry) MutateFirstName(v string) error {
+	return x._message.SetString(0, v)
+}
+
+func (x *PhonebookEntry) StringFirstName() string {
+	return fmt.Sprintf(x.FirstName())
+}
+
+func (x *PhonebookEntry) LastName() string {
+	return x._message.GetString(1)
+}
+
+func (x *PhonebookEntry) RawLastName() []byte {
+	return x._message.RawBufferForField(1, 0)
+}
+
+func (x *PhonebookEntry) RawLastNameWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(1, 0)
+}
+
+func (x *PhonebookEntry) MutateLastName(v string) error {
+	return x._message.SetString(1, v)
+}
+
+func (x *PhonebookEntry) StringLastName() string {
+	return fmt.Sprintf(x.LastName())
+}
+
+func (x *PhonebookEntry) Phone() uint64 {
+	return x._message.GetUint64(2)
+}
+
+func (x *PhonebookEntry) RawPhone() []byte {
+	return x._message.RawBufferForField(2, 0)
+}
+
+func (x *PhonebookEntry) MutatePhone(v uint64) error {
+	return x._message.SetUint64(2, v)
+}
+
+func (x *PhonebookEntry) StringPhone() string {
+	return fmt.Sprintf("%x", x.Phone())
+}
+
+func (x *PhonebookEntry) OrbsAddress() []byte {
+	return x._message.GetBytes(3)
+}
+
+func (x *PhonebookEntry) RawOrbsAddress() []byte {
+	return x._message.RawBufferForField(3, 0)
+}
+
+func (x *PhonebookEntry) RawOrbsAddressWithHeader() []byte {
+	return x._message.RawBufferWithHeaderForField(3, 0)
+}
+
+func (x *PhonebookEntry) MutateOrbsAddress(v []byte) error {
+	return x._message.SetBytes(3, v)
+}
+
+func (x *PhonebookEntry) StringOrbsAddress() string {
+	return fmt.Sprintf("%x", x.OrbsAddress())
+}
+
+// builder
+
+type PhonebookEntryBuilder struct {
+	FirstName string
+	LastName string
+	Phone uint64
+	OrbsAddress []byte
+
+	// internal
+	// implements membuffers.Builder
+	_builder membuffers.InternalBuilder
+	_overrideWithRawBuffer []byte
+}
+
+func (w *PhonebookEntryBuilder) Write(buf []byte) (err error) {
+	if w == nil {
+		return
+	}
+	w._builder.NotifyBuildStart()
+	defer w._builder.NotifyBuildEnd()
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	if w._overrideWithRawBuffer != nil {
+		return w._builder.WriteOverrideWithRawBuffer(buf, w._overrideWithRawBuffer)
+	}
+	w._builder.Reset()
+	w._builder.WriteString(buf, w.FirstName)
+	w._builder.WriteString(buf, w.LastName)
+	w._builder.WriteUint64(buf, w.Phone)
+	w._builder.WriteBytes(buf, w.OrbsAddress)
+	return nil
+}
+
+func (w *PhonebookEntryBuilder) HexDump(prefix string, offsetFromStart membuffers.Offset) (err error) {
+	if w == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = &membuffers.ErrBufferOverrun{}
+		}
+	}()
+	w._builder.Reset()
+	w._builder.HexDumpString(prefix, offsetFromStart, "PhonebookEntry.FirstName", w.FirstName)
+	w._builder.HexDumpString(prefix, offsetFromStart, "PhonebookEntry.LastName", w.LastName)
+	w._builder.HexDumpUint64(prefix, offsetFromStart, "PhonebookEntry.Phone", w.Phone)
+	w._builder.HexDumpBytes(prefix, offsetFromStart, "PhonebookEntry.OrbsAddress", w.OrbsAddress)
+	return nil
+}
+
+func (w *PhonebookEntryBuilder) GetSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryBuilder) CalcRequiredSize() membuffers.Offset {
+	if w == nil {
+		return 0
+	}
+	w.Write(nil)
+	return w._builder.GetSize()
+}
+
+func (w *PhonebookEntryBuilder) Build() *PhonebookEntry {
+	buf := make([]byte, w.CalcRequiredSize())
+	if w.Write(buf) != nil {
+		return nil
+	}
+	return PhonebookEntryReader(buf)
+}
+
+func PhonebookEntryBuilderFromRaw(raw []byte) *PhonebookEntryBuilder {
+	return &PhonebookEntryBuilder{_overrideWithRawBuffer: raw}
+}
+

--- a/examples/membuffers/test/harness.go
+++ b/examples/membuffers/test/harness.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"fmt"
+	"github.com/orbs-network/orbs-client-sdk-go/codec"
+	"github.com/orbs-network/orbs-client-sdk-go/orbs"
+	"github.com/orbs-network/orbs-contract-sdk/go/examples/test"
+	"time"
+)
+
+type harness struct {
+	phonebookContract phonebookContract
+}
+
+type contract struct {
+	client *orbs.OrbsClient
+	name   string
+}
+
+type phonebookContract contract
+
+func newHarness() *harness {
+	client := orbs.NewClient(test.GetGammaEndpoint(), 42, codec.NETWORK_TYPE_TEST_NET)
+
+	return &harness{
+		phonebookContract: phonebookContract{
+			name:   fmt.Sprintf("Phone%d", time.Now().UnixNano()),
+			client: client,
+		},
+	}
+}

--- a/examples/membuffers/test/main_test.go
+++ b/examples/membuffers/test/main_test.go
@@ -1,0 +1,57 @@
+// Copyright 2019 the orbs-contract-sdk authors
+// This file is part of the orbs-contract-sdk library in the Orbs project.
+//
+// This source code is licensed under the MIT license found in the LICENSE file in the root directory of this source tree.
+// The above notice should be included in all copies or substantial portions of the software.
+
+package test
+
+import (
+	"github.com/orbs-network/orbs-client-sdk-go/codec"
+	"github.com/orbs-network/orbs-client-sdk-go/orbs"
+	"github.com/orbs-network/orbs-contract-sdk/go/examples/test"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestPhonebook(t *testing.T) {
+	drakulaAccount, _ := orbs.CreateAccount()
+
+	h := newHarness()
+	h.phonebookContract.deployContract(t, drakulaAccount)
+
+	drakula, err := h.phonebookContract.register(t, drakulaAccount, (&PhonebookEntryBuilder{
+		FirstName: "Count",
+		LastName: "Drakula",
+		Phone: 1234567890,
+	}).Build())
+	require.NoError(t, err)
+	require.EqualValues(t, codec.EXECUTION_RESULT_SUCCESS, drakula.ExecutionResult)
+
+	nosferatuAccount, _ := orbs.CreateAccount()
+	nosferatu, err := h.phonebookContract.register(t, nosferatuAccount, (&PhonebookEntryBuilder{
+		FirstName: "Count",
+		LastName: "Nosferatu",
+		Phone: 987654321,
+	}).Build())
+	require.NoError(t, err)
+	require.EqualValues(t, codec.EXECUTION_RESULT_SUCCESS, nosferatu.ExecutionResult)
+
+
+	require.True(t, test.Eventually(1*time.Second, func() bool {
+		entry := h.phonebookContract.get(t, drakulaAccount, drakulaAccount.AddressAsBytes())
+		return entry.FirstName() == "Count" && entry.LastName() == "Drakula" && entry.Phone() == uint64(1234567890)
+	}))
+
+	require.True(t, test.Eventually(1*time.Second, func() bool {
+		list  := h.phonebookContract.list(t, drakulaAccount)
+		var entries []*PhonebookEntry
+		for i := list.ListIterator(); i.HasNext(); {
+			entries = append(entries, i.NextList())
+		}
+
+		return len(entries) == 2 && entries[0].LastName() == "Drakula" && entries[1].LastName() == "Nosferatu"
+	}))
+}
+

--- a/examples/membuffers/test/phonebook_harness.go
+++ b/examples/membuffers/test/phonebook_harness.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"github.com/orbs-network/orbs-client-sdk-go/codec"
+	"github.com/orbs-network/orbs-client-sdk-go/orbs"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"testing"
+)
+
+func (h *phonebookContract) deployContract(t *testing.T, sender *orbs.OrbsAccount) {
+	contractSource, err := ioutil.ReadFile("../phonebook/contract.go")
+	require.NoError(t, err)
+
+	datastructuresSouce, err := ioutil.ReadFile("../phonebook/datastructures.mb.go")
+	require.NoError(t, err)
+
+	deployTx, _, err := h.client.CreateTransaction(sender.PublicKey, sender.PrivateKey,
+		"_Deployments", "deployService", h.name, uint32(1), contractSource, datastructuresSouce)
+	require.NoError(t, err)
+
+	deployResponse, err := h.client.SendTransaction(deployTx)
+	require.NoError(t, err)
+
+	require.EqualValues(t, codec.EXECUTION_RESULT_SUCCESS, deployResponse.ExecutionResult)
+}
+
+func (h *phonebookContract) list(t *testing.T, sender *orbs.OrbsAccount) *PhonebookEntryList {
+	query, err := h.client.CreateQuery(sender.PublicKey, h.name, "list")
+	require.NoError(t, err)
+
+	queryResponse, err := h.client.SendQuery(query)
+	require.NoError(t, err)
+
+	return PhonebookEntryListReader(queryResponse.OutputArguments[0].([]byte))
+}
+
+func (h *phonebookContract) register(t *testing.T, sender *orbs.OrbsAccount, entry *PhonebookEntry) (*codec.SendTransactionResponse, error) {
+	tx, _, err := h.client.CreateTransaction(sender.PublicKey, sender.PrivateKey, h.name, "register", entry.Raw())
+	require.NoError(t, err)
+
+	return h.client.SendTransaction(tx)
+}
+
+func (h *phonebookContract) get(t *testing.T, sender *orbs.OrbsAccount, address []byte) *PhonebookEntry {
+	tx, err := h.client.CreateQuery(sender.PublicKey, h.name, "get", address)
+	require.NoError(t, err)
+
+	response, err := h.client.SendQuery(tx)
+	require.NoError(t, err)
+
+	return PhonebookEntryReader(response.OutputArguments[0].([]byte))
+}
+


### PR DESCRIPTION
Lessons learned:

* Membuffers are not equipped for moving data between readers and builders: https://github.com/orbs-network/membuffers/issues/26
* Membuffers version on homebrew is outdated: https://github.com/orbs-network/membuffers/issues/27
* Some packages need to be whitelisted for it to work: https://github.com/orbs-network/membuffers/issues/28 ; namely, `github.com/orbs-network/membuffers/go` and `fmt`.